### PR TITLE
Add `Format-Coverage -PesterResults`

### DIFF
--- a/Coveralls.psm1
+++ b/Coveralls.psm1
@@ -140,7 +140,9 @@ function Format-Coverage {
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true,Position=1)]
+        [parameter(Mandatory = $true, Position = 0, ParameterSetName = "PesterResults")]
+        $PesterResults,
+        [parameter(Mandatory = $true, Position = 1, ParameterSetName = "Include")]
         $Include,
         [parameter(Mandatory = $true,Position=2)]
         [string]
@@ -150,7 +152,9 @@ function Format-Coverage {
     )
 
     $fileCoverageArray = @()
-    $pesterResults = Invoke-Pester -CodeCoverage $Include -Quiet -PassThru
+    if (!$pesterResults) {
+        $pesterResults = Invoke-Pester -CodeCoverage $Include -Quiet -PassThru
+    }
     foreach ($file in $Include) {
         $hitcommands = Get-CommandsForFile -Commands $pesterResults.CodeCoverage.HitCommands -File $file
         $missedCommands = Get-CommandsForFile -Commands $pesterResults.CodeCoverage.MissedCommands -File $file

--- a/Coveralls.psm1
+++ b/Coveralls.psm1
@@ -155,6 +155,10 @@ function Format-Coverage {
     if (!$pesterResults) {
         $pesterResults = Invoke-Pester -CodeCoverage $Include -Quiet -PassThru
     }
+    if (!$pesterResults.CodeCoverage) {
+        Write-Error 'Please provide pester results with code coverage using the -CodeCoverage parameter'
+        return;
+    }
     foreach ($file in $Include) {
         $hitcommands = Get-CommandsForFile -Commands $pesterResults.CodeCoverage.HitCommands -File $file
         $missedCommands = Get-CommandsForFile -Commands $pesterResults.CodeCoverage.MissedCommands -File $file


### PR DESCRIPTION
Following on from https://github.com/dahlbyk/posh-git/pull/461, it would be nice if PR builds could report coverage in their build log even if it's not pushed to Coveralls. That's not currently possible because the `Format-Coverage` call requires `-CoverallsApiToken`.

My proposal is pretty simple: add a second parameter set that accepts an existing set of Pester results.